### PR TITLE
Test more click versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ script:
   - py.test tests --cov click_aliases --cov-report term-missing
   - pip install 'click>6,<7'
   - py.test tests --cov click_aliases --cov-report term-missing --cov-append
+  - pip install 'click>5,<6'
+  - py.test tests --cov click_aliases --cov-report term-missing --cov-append
 
 after_success:
   - coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,20 @@
 [tox]
-toxenv = py{27,34,35,36,37}-click{6,7}
+toxenv = py{27,34,35,36,37}-click{3,40,41,50,51,62,63,64,65,66,6x,7}
 
 [testenv]
 passenv = LANG
 deps =
-  click6: click>6,<7
+  click3: click>=3,<4
+  click40: click==4.0
+  click41: click==4.1
+  click50: click==5.0
+  click51: click==5.1
+  click62: click==6.2
+  click63: click==6.3
+  click64: click==6.4
+  click65: click==6.5
+  click66: click==6.6
+  click6x: click>6,<7
   click7: click>=7,<8
   pytest
 commands = py.test


### PR DESCRIPTION
tox is not used by CI, however it can now be used to
verify compatibility with click version 3.3+, and CI
is checking compatibility with click version 5.1+.

Related to https://github.com/click-contrib/click-aliases/issues/5