### PR TITLE
do not explode if 'aliases=[]' is specified

### DIFF
--- a/click_aliases/__init__.py
+++ b/click_aliases/__init__.py
@@ -62,7 +62,10 @@ class ClickAliasedGroup(click.Group):
 
         sub_commands = self.list_commands(ctx)
 
-        max_len = max(len(cmd) for cmd in sub_commands)
+        max_len = 0
+        if len(sub_commands) > 0:
+            max_len = max(len(cmd) for cmd in sub_commands)        
+            
         limit = formatter.width - 6 - max_len
 
         for sub_command in sub_commands:


### PR DESCRIPTION
While designing the CLI interface, one tends to play with different options and may leave the `aliases` iterable empty. This PR fixes click-aliases exploding if there are no subcommands, therefore the max() function breaks:

```
Traceback (most recent call last):
  File "/home/kraptor/.cache/pypoetry/virtualenvs/packtrack-Oxe3-kYo-py3.10/bin/ptc", line 6, in <module>
    sys.exit(main())
  File "/home/kraptor/repos/in/packtrack/packtrack/client/__main__.py", line 261, in main
    cli()
  File "/usr/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3.10/site-packages/click/core.py", line 1655, in invoke
    sub_ctx = cmd.make_context(cmd_name, args, parent=ctx)
  File "/usr/lib/python3.10/site-packages/click/core.py", line 920, in make_context
    self.parse_args(ctx, args)
  File "/usr/lib/python3.10/site-packages/click/core.py", line 1610, in parse_args
    echo(ctx.get_help(), color=ctx.color)
  File "/usr/lib/python3.10/site-packages/click/core.py", line 699, in get_help
    return self.command.get_help(self)
  File "/usr/lib/python3.10/site-packages/click/core.py", line 1298, in get_help
    self.format_help(ctx, formatter)
  File "/usr/lib/python3.10/site-packages/click/core.py", line 1331, in format_help
    self.format_options(ctx, formatter)
  File "/usr/lib/python3.10/site-packages/click/core.py", line 1533, in format_options
    self.format_commands(ctx, formatter)
  File "/home/kraptor/.cache/pypoetry/virtualenvs/packtrack-Oxe3-kYo-py3.10/lib/python3.10/site-packages/click_aliases/__init__.py", line 65, in format_commands
    max_len = max(len(cmd) for cmd in sub_commands)
ValueError: max() arg is an empty sequence
```
