### PR TITLE
Add alias suppot for add_command function

### DIFF
--- a/click_aliases/__init__.py
+++ b/click_aliases/__init__.py
@@ -14,6 +14,20 @@ class ClickAliasedGroup(click.Group):
         self._commands = {}
         self._aliases = {}
 
+    def add_command(self, *args, **kwargs):
+        aliases = kwargs.pop('aliases', [])
+        super(ClickAliasedGroup, self).add_command(*args, **kwargs)
+        if aliases:
+            cmd = args[0]
+            name = args[1] if len(args) > 1 else None
+            name = name or cmd.name
+            if name is None:
+                raise TypeError('Command has no name.')
+
+            self._commands[name] = aliases
+            for alias in aliases:
+                self._aliases[alias] = cmd.name
+
     def command(self, *args, **kwargs):
         aliases = kwargs.pop('aliases', [])
         decorator = super(ClickAliasedGroup, self).command(*args, **kwargs)

--- a/examples/bar/subcommand.py
+++ b/examples/bar/subcommand.py
@@ -1,0 +1,6 @@
+import click
+
+@click.command(name='bar')
+def bar():
+    """Prints 'Hello, world!'."""
+    click.echo('Hello, world!')

--- a/examples/foo.py
+++ b/examples/foo.py
@@ -1,0 +1,16 @@
+import click
+
+from click_aliases import ClickAliasedGroup
+from bar.subcommand import bar
+
+
+
+@click.group(cls=ClickAliasedGroup)
+def cli():
+    pass
+
+
+cli.add_command(bar, aliases=['spam'])
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
Currently we can create command aliases by providing a list of strings to the decorator. This method works perfectly well if the command group and its subcommands are written in the same file.
However, if a subcommand is written in another file aliases cannot be specified. This PR fixes this problem by overriding the `add_command` method.

Example:

```py
import click
from click_aliases import ClickAliasedGroup

@click.group(cls=ClickAliasesGroup)
def cli():
    pass


@click.command()
def subcommand():
   click.echo('Hello, world!')

cli.add_command(subcommand, aliases=['foobar'])
```