### PR TITLE
Add PEP 484 typing

### DIFF
--- a/click_aliases/__init__.py
+++ b/click_aliases/__init__.py
@@ -3,18 +3,20 @@
     to provide a group or command with aliases.
 """
 
+import typing as t
+
 import click
 
 _click7 = click.__version__[0] >= "7"
 
 
 class ClickAliasedGroup(click.Group):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: t.Any, **kwargs: t.Any) -> None:
         super().__init__(*args, **kwargs)
-        self._commands = {}
-        self._aliases = {}
+        self._commands: t.Dict[str, list[str]] = {}
+        self._aliases: t.Dict[str, str] = {}
 
-    def add_command(self, *args, **kwargs):
+    def add_command(self, *args: t.Any, **kwargs: t.Any) -> None:
         aliases = kwargs.pop("aliases", [])
         super().add_command(*args, **kwargs)
         if aliases:
@@ -28,7 +30,9 @@ class ClickAliasedGroup(click.Group):
             for alias in aliases:
                 self._aliases[alias] = cmd.name
 
-    def command(self, *args, **kwargs):
+    def command(  # type: ignore[override]
+        self, *args: t.Any, **kwargs: t.Any
+    ) -> t.Union[t.Callable[[t.Callable[..., t.Any]], click.Command], click.Command]:
         aliases = kwargs.pop("aliases", [])
         decorator = super().command(*args, **kwargs)
         if not aliases:
@@ -44,7 +48,9 @@ class ClickAliasedGroup(click.Group):
 
         return _decorator
 
-    def group(self, *args, **kwargs):
+    def group(  # type: ignore[override]
+        self, *args: t.Any, **kwargs: t.Any
+    ) -> t.Union[t.Callable[[t.Callable[..., t.Any]], click.Group], click.Group]:
         aliases = kwargs.pop("aliases", [])
         decorator = super().group(*args, **kwargs)
         if not aliases:
@@ -60,19 +66,19 @@ class ClickAliasedGroup(click.Group):
 
         return _decorator
 
-    def resolve_alias(self, cmd_name):
+    def resolve_alias(self, cmd_name: str) -> str:
         if cmd_name in self._aliases:
             return self._aliases[cmd_name]
         return cmd_name
 
-    def get_command(self, ctx, cmd_name):
+    def get_command(self, ctx: click.Context, cmd_name: str) -> t.Optional[click.Command]:
         cmd_name = self.resolve_alias(cmd_name)
         command = super().get_command(ctx, cmd_name)
         if command:
             return command
         return None
 
-    def format_commands(self, ctx, formatter):
+    def format_commands(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
         rows = []
 
         sub_commands = self.list_commands(ctx)


### PR DESCRIPTION
This copies the style used in Click's code and maintains compatibility with Python 3.9. Most of this does not matter but it is needed to make Mypy/Pyright happy about the `@click.group` decorator with the `cls` keyword and the `add_command` call.

![image](https://github.com/click-contrib/click-aliases/assets/724848/47a516cf-2689-45d8-9820-03ee0e8f6531)

![image](https://github.com/click-contrib/click-aliases/assets/724848/0522c3a6-1375-4137-b2db-2625a1e2a78c)
