### PR TITLE
fix cmd.name to name

### DIFF
--- a/click_aliases/__init__.py
+++ b/click_aliases/__init__.py
@@ -26,7 +26,7 @@ class ClickAliasedGroup(click.Group):
 
             self._commands[name] = aliases
             for alias in aliases:
-                self._aliases[alias] = cmd.name
+                self._aliases[alias] = name
 
     def command(self, *args, **kwargs):
         aliases = kwargs.pop("aliases", [])


### PR DESCRIPTION
when add_command function has **name** and **aliases** like 

```python
_cmd.add_command(_other_cmd, "command", aliases=["cmd"])
```

aliases does not work.