### PR TITLE
fix #27: Use `importlib.metadata.version` instead of `__version__`

### DIFF
--- a/click_aliases/__init__.py
+++ b/click_aliases/__init__.py
@@ -1,20 +1,21 @@
 """
-    Extension for the python ``click`` module
-    to provide a group or command with aliases.
+Extension for the python ``click`` module
+to provide a group or command with aliases.
 """
 
 import typing as t
+from importlib import metadata
 
 import click
 
-_click7 = click.__version__[0] >= "7"
+_click7: bool = metadata.version("click")[0] >= "7"
 
 
 class ClickAliasedGroup(click.Group):
     def __init__(self, *args: t.Any, **kwargs: t.Any) -> None:
         super().__init__(*args, **kwargs)
-        self._commands: t.Dict[str, list[str]] = {}
-        self._aliases: t.Dict[str, str] = {}
+        self._commands: dict[str, list[str]] = {}
+        self._aliases: dict[str, str] = {}
 
     def add_command(self, *args: t.Any, **kwargs: t.Any) -> None:
         aliases = kwargs.pop("aliases", [])
@@ -32,7 +33,7 @@ class ClickAliasedGroup(click.Group):
 
     def command(  # type: ignore[override]
         self, *args: t.Any, **kwargs: t.Any
-    ) -> t.Union[t.Callable[[t.Callable[..., t.Any]], click.Command], click.Command]:
+    ) -> t.Callable[[t.Callable[..., t.Any]], click.Command] | click.Command:
         aliases = kwargs.pop("aliases", [])
         decorator = super().command(*args, **kwargs)
         if not aliases:
@@ -50,7 +51,7 @@ class ClickAliasedGroup(click.Group):
 
     def group(  # type: ignore[override]
         self, *args: t.Any, **kwargs: t.Any
-    ) -> t.Union[t.Callable[[t.Callable[..., t.Any]], click.Group], click.Group]:
+    ) -> t.Callable[[t.Callable[..., t.Any]], click.Group] | click.Group:
         aliases = kwargs.pop("aliases", [])
         decorator = super().group(*args, **kwargs)
         if not aliases:
@@ -71,7 +72,7 @@ class ClickAliasedGroup(click.Group):
             return self._aliases[cmd_name]
         return cmd_name
 
-    def get_command(self, ctx: click.Context, cmd_name: str) -> t.Optional[click.Command]:
+    def get_command(self, ctx: click.Context, cmd_name: str) -> click.Command | None:
         cmd_name = self.resolve_alias(cmd_name)
         command = super().get_command(ctx, cmd_name)
         if command:


### PR DESCRIPTION
Resolves a warning about accessing click's `__version__` string directly. That string will be removed in click version 9. 